### PR TITLE
[http][server] Access log

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,7 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/dyweb/gommon"
   packages = [
     "cast",
@@ -21,7 +22,7 @@
     "util/logutil",
     "util/runtimeutil"
   ]
-  revision = "0fae72685dc7fc177dba16ab782195ded5dcabc2"
+  revision = "391e17305c8fd0af4d0d83aad7aba55f768089b7"
 
 [[projects]]
   name = "github.com/go-sql-driver/mysql"
@@ -87,6 +88,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cb56a5737caf21f283ad1a3b16dae94f3979f3120cc1c08a3a13d4c3b4ce1bdf"
+  inputs-digest = "330894200cda862c088c11d49359c01efaba63014b6bebacc6f0ee1bc802161d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@ ignored = [
 # TODO: we lock gommon version because dep will use lastest release but gommon is adding new features when go.ice need it ...
 [[constraint]]
   name = "github.com/dyweb/gommon"
-  revision = "0fae72685dc7fc177dba16ab782195ded5dcabc2"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/go-sql-driver/mysql"

--- a/doc/third_party/grpc.md
+++ b/doc/third_party/grpc.md
@@ -1,0 +1,7 @@
+# GRPC
+
+````bash
+# TODO: install protoc, it seems I installed it using package manager
+# this will install the binary, which is required by protoc
+go get -u github.com/gogo/protobuf/protoc-gen-gogo
+````

--- a/example/github/icehubd.yml
+++ b/example/github/icehubd.yml
@@ -27,7 +27,7 @@ db-manager:
 # default http and grpc server config
 http:
   addr: :7080
-  secure: false
+  secure: true
   cert: icehub.crt
   key: icehub.key
 grpc:

--- a/example/github/pkg/server/grpc/service.proto
+++ b/example/github/pkg/server/grpc/service.proto
@@ -1,0 +1,24 @@
+// protoc --proto_path=/home/at15/workspace/src/:. --gogo_out=plugins=grpc:. service.proto
+syntax = "proto3";
+
+package grpc;
+
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+
+option (gogoproto.sizer_all) = true;
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.unmarshaler_all) = true;
+option (gogoproto.goproto_getters_all) = false;
+
+// TODO: can't use Ping as both message and method name ?
+message PingMessage {
+    string name = 1;
+}
+
+message Pong {
+    string name = 1;
+}
+
+service IceHub {
+    rpc Ping (PingMessage) returns (Pong) {}
+}

--- a/example/github/pkg/service/ping.go
+++ b/example/github/pkg/service/ping.go
@@ -1,0 +1,6 @@
+package service
+
+// TODO: what would gRPC generated interface be ...
+type PingService interface {
+
+}

--- a/ice/transport/http/access_log.go
+++ b/ice/transport/http/access_log.go
@@ -1,0 +1,101 @@
+package http
+
+import "net/http"
+
+// HTTP Access Log
+
+var _ http.ResponseWriter = (*TrackedWriter)(nil)
+var _ http.Flusher = (*TrackedWriter)(nil)
+var _ http.Pusher = (*TrackedWriter)(nil)
+var _ http.CloseNotifier = (*TrackedWriter)(nil)
+
+// TrackedWriter keeps track of status code and bytes written so it can be used by logger.
+// It proxies all the interfaces except Hijacker, since it is not supported by HTTP/2.
+// Most methods comments are copied from net/http
+// It is based on https://github.com/gorilla/handlers but put all interface on one struct
+type TrackedWriter struct {
+	w      http.ResponseWriter
+	status int
+	size   int
+}
+
+// Header returns the header map of the underlying ResponseWriter
+//
+// Changing the header map after a call to WriteHeader (or
+// Write) has no effect unless the modified headers are
+// trailers.
+func (tracker *TrackedWriter) Header() http.Header {
+	return tracker.w.Header()
+}
+
+// Write keeps track of bytes written of the underlying ResponseWriter
+//
+// Write writes the data to the connection as part of an HTTP reply.
+//
+// If WriteHeader has not yet been called, Write calls
+// WriteHeader(http.StatusOK) before writing the data. If the Header
+// does not contain a Content-Type line, Write adds a Content-Type set
+// to the result of passing the initial 512 bytes of written data to
+// DetectContentType.
+func (tracker *TrackedWriter) Write(b []byte) (int, error) {
+	size, err := tracker.w.Write(b)
+	tracker.size += size
+	return size, err
+}
+
+// WriteHeader keep track of status code and call the underlying ResponseWriter
+//
+// WriteHeader sends an HTTP response header with status code.
+// If WriteHeader is not called explicitly, the first call to Write
+// will trigger an implicit WriteHeader(http.StatusOK).
+// Thus explicit calls to WriteHeader are mainly used to
+// send error codes.
+func (tracker *TrackedWriter) WriteHeader(status int) {
+	tracker.status = status
+	tracker.w.WriteHeader(status)
+}
+
+// Status return the tracked status code, returns 0 if WriteHeader has not been called
+func (tracker *TrackedWriter) Status() int {
+	return tracker.status
+}
+
+// Size return number of bytes written through Write, returns 0 if Write has not been called
+func (tracker *TrackedWriter) Size() int {
+	return tracker.size
+}
+
+// Flush calls Flush on underlying ResponseWriter if it implemented http.Flusher
+//
+// Flusher interface is implemented by ResponseWriters that allow
+// an HTTP handler to flush buffered data to the client.
+// The default HTTP/1.x and HTTP/2 ResponseWriter implementations
+// support Flusher
+func (tracker *TrackedWriter) Flush() {
+	if f, ok := tracker.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Push returns http.ErrNotSupported if underlying ResponseWriter does not implement http.Pusher
+//
+// Push initiates an HTTP/2 server push, returns ErrNotSupported if the client has disabled push or if push
+// is not supported on the underlying connection.
+func (tracker *TrackedWriter) Push(target string, opts *http.PushOptions) error {
+	if p, ok := tracker.w.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
+// CloseNotify returns nil if underlying ResponseWriter does not implement http.CloseNotifier
+//
+// The CloseNotifier interface is implemented by ResponseWriters which
+// allow detecting when the underlying connection has gone away
+func (tracker *TrackedWriter) CloseNotify() <-chan bool {
+	if c, ok := tracker.w.(http.CloseNotifier); ok {
+		return c.CloseNotify()
+	}
+	// FIXME: what should be returned, may nil would work? .. never used CloseNotify before
+	return nil
+}

--- a/ice/transport/http/server.go
+++ b/ice/transport/http/server.go
@@ -27,6 +27,7 @@ func NewServer(cfg config.HttpServerConfig, h nhttp.Handler) *Server {
 	srv.Handler = nhttp.HandlerFunc(func(w nhttp.ResponseWriter, r *nhttp.Request) {
 		tw := &TrackedWriter{w: w, status: 200}
 		h.ServeHTTP(tw, r)
+		// TODO: duration, but gommon/log can't handle float?
 		log.InfoF("http", dlog.Fields{
 			dlog.Str("remote", r.RemoteAddr),
 			dlog.Str("url", r.URL.String()),

--- a/ice/transport/http/server.go
+++ b/ice/transport/http/server.go
@@ -19,6 +19,7 @@ type Server struct {
 }
 
 func NewServer(cfg config.HttpServerConfig, h nhttp.Handler) *Server {
+	// TODO： http server also accept stdlib logger
 	srv := &nhttp.Server{
 		Addr: cfg.Addr,
 	}


### PR DESCRIPTION
Related #18 

- [x] wrap http response writer
- [x] support TLS using self signed 
  - [ ] optional, let's encrypt #15 
- [ ] grpc & http
  - [ ] need to see how gRPC define service and try to make it work with http
  - [ ] might use grpc generated file instead of handwritten go structs
  - [ ] trace or log grpc?
- [ ] ingest the log to elastic search? (sounds like a good idea ...)
  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-nginx.html it can even show visitor address in dashboard ... amazing ...
- [ ] consider adding tracing to it
  - might take the chance to refactor the broken tracing package ....

gommon

- [ ] need to be able to config logger by name? so they can have different handlers
- [ ] support time duration as field

Don't know how to fix

- can't redirect http traffic to http
  - https://github.com/unrolled/secure requires two port, one for http and one for https
  - if same port is needed, need to sniff packages and hack the logic of http server https://groups.google.com/forum/#!topic/golang-nuts/4oZp1csAm2o
- might need to hijack `net/http` logger

````
2018/02/08 17:08:22 http: TLS handshake error from [::1]:41882: tls: first record does not look like a TLS handshake
2018/02/08 17:08:30 http: TLS handshake error from [::1]:41884: tls: first record does not look like a TLS handshake
2018/02/08 17:08:30 http: TLS handshake error from [::1]:41886: tls: first record does not look like a TLS handshake
2018/02/08 17:08:35 http: TLS handshake error from [::1]:41888: tls: first record does not look like a TLS handshake
2018/02/08 17:08:46 http2: server: error reading preface from client [::1]:41894: read tcp [::1]:7080->[::1]:41894: read: connection reset by peer
````